### PR TITLE
Named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ In this exercise, your task is to build a workflow for testing people for a bact
 1. Define a variable in the module to hold a number that you can use when setting the primary key for each person you create _(i.e. the `id` property)_. It should have an initial value of 1. Use this when setting the id property on the person. You will need to increase this value by one after each new person is created.
 1. Define and export a function named `testPerson`.
 1. The `testPerson` function must accept the following values as input _(i.e. it needs parameters)_, in the following order.
-    1. First name of the person being tested (e.g. "Kelly", "Peter")
-    1. Age of the person (e.g. 31, 65)
-    1. Person's temperature (e.g. 98, 103)
+   1. First name of the person being tested (e.g. "Kelly", "Peter")
+   1. Age of the person (e.g. 31, 65)
+   1. Person's temperature (e.g. 98, 103)
 1. The `testPerson` function must return an object with the following properties on it. The `id` value you defined earlier should be incremented by 1 each time a person is tested.
-    1. `firstName` whose value comes from the parameter
-    1. `age` whose value comes from the parameter
-    1. `temperature` whose value comes from the parameter
-    1. `id` whose value comes from the incremented module variable
+   1. `firstName` whose value comes from the parameter
+   1. `age` whose value comes from the parameter
+   1. `temperature` whose value comes from the parameter
+   1. `id` whose value comes from the incremented module variable
 
 #### Checking Your Work
 
@@ -43,17 +43,15 @@ Once you have it working, test 5 people in the `main.js` module.
 ## Clinical Consultation
 
 1. Define a `scripts/Clinic.js` module.
-1. Define a variable in the module that will store the people objects after they have been diagnosed in the clinic. Its initial value should be an empty array.
-1. Define and export an object named `clinic` which should have 2 properties on it:
-    1. A key of `usePatients` and its value is a function that should return the array of diagnosed patients.
-    1. A key of `diagnose` and its value is a function that is responsible for providing a diagnosis for a tested person.
-1. The function must accept the following values as input _(i.e. it needs parameters)_, in the following order.
-    1. An object representing a person who was tested with the `testPerson` function.
-    1. A number specifying how many days the person has been exhibiting symptoms.
-1. The function must add a new property of `diagnosed` with the value of `true` to the object. If you don't remember, you can easily [add new properties to objects in JavaScript](https://www.dyn-web.com/tutorials/object-literal/properties.php).
-1. The function must also add a new property of `infected` to the object.
-    1. If the person's temperature is above 101 and the number of days the person has been symptomatic is greater than, or equal to, 4 then `infected` property must have a value of `true`.
-    1. Otherwise, the `infected` property must have a value of `false`.
+1. Define a variable in the module that will store the people objects after they have been diagnosed in the clinic. Its initial value should be an empty array. This variable should _not_ be exported.
+1. Define and export a function named `usePatients`. The function should return a copy of the array of diagnosed patients.
+1. In the same file, define and export a function named `diagnose` which will be responsible for providing a diagnosis for a tested person. The function must accept the following values as input _(i.e. it needs parameters)_, in the following order.
+   1. An object representing a person who was tested with the `testPerson` function.
+   1. A number specifying how many days the person has been exhibiting symptoms.
+1. The `diagnose` function must add a new property of `diagnosed` with the value of `true` to the object. If you don't remember, you can easily [add new properties to objects in JavaScript](https://www.dyn-web.com/tutorials/object-literal/properties.php).
+1. The `diagnose` function must also add a new property of `infected` to the object.
+   1. If the person's temperature is above 101 and the number of days the person has been symptomatic is greater than, or equal to, 4 then `infected` property must have a value of `true`.
+   1. Otherwise, the `infected` property must have a value of `false`.
 1. After both of the new properties have been added, add the person to the array of diagnosed people. Recall which method is used to add new items to an array.
 1. Finally, the function should return the augmented object.
 
@@ -65,10 +63,10 @@ To check your work, make sure that at least one of the people is infected by pro
 
 Also look at your terminal window that is running the tests and make sure that the following tests pass.
 
-* `Person is diagnosed`
-* `Person is infected when temperature and symptomatic days are too high`
-* `Person is not infected when days are too few`
-* `Person is not infected when no conditions met`
+- `Person is diagnosed`
+- `Person is infected when temperature and symptomatic days are too high`
+- `Person is not infected when days are too few`
+- `Person is not infected when no conditions met`
 
 > 2 out of 3 Test Suites should be passing.
 
@@ -87,22 +85,10 @@ Your next task is to create HTML representations of the people who have been tes
 
 1. Create a `scripts/PatientList.js` module.
 1. Define and export a `PatientList` function.
-1. The `PatientList` function must import that array of patients from the from the `Clinic.js` module.
+1. The `PatientList` function must use that array of patients from the from the `Clinic.js` module.
 1. The `PatientList` function must convert each object in the array to an HTML representation string.
-The resulting HTML should look like the following example. Recall the `${}` syntax for interpolating JavaScript variables into string templates.
-    ```html
-    <section class="patient" id="patient--1">
-        <h2 class="patient__name">Doug</h2>
-        <div class="patient__properties">
-            <p>Age: 32</p>
-            <p>Temperature: 101</p>
-            <p>Diagnosed: true</p>
-        </div>
-        <div class="patient_diagnosis">
-            Infected: false
-        </div>
-    </section>
-    ```
+   The resulting HTML should look like the following example. Recall the `${}` syntax for interpolating JavaScript variables into string templates.
+   `html <section class="patient" id="patient--1"> <h2 class="patient__name">Doug</h2> <div class="patient__properties"> <p>Age: 32</p> <p>Temperature: 101</p> <p>Diagnosed: true</p> </div> <div class="patient_diagnosis"> Infected: false </div> </section> `
 1. The function must put all of the HTML representations into a single string. Recall that there are ways to turn an array's values into a single string.
 1. The function then must return that single string that has all of the patient HTML representation in it.
 1. In the `main.js` module, invoke the `PatientList` component function. Take the string of HTML representations that it returns and update the inner HTML of the article element you created in `index.html`. You need to remember how to get a reference to DOM element in JavaScript and then assign it some HTML.
@@ -115,7 +101,7 @@ Make sure your web server is running, and then visit http://localhost:<yourPort#
 
 Then look at your terminal window that is running the tests and make sure that the following tests pass.
 
-* `Patients are rendered to DOM`
+- `Patients are rendered to DOM`
 
 > All 3 Test Suites should be passing.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,17 @@ Your next task is to create HTML representations of the people who have been tes
 1. The `PatientList` function must use that array of patients from the from the `Clinic.js` module.
 1. The `PatientList` function must convert each object in the array to an HTML representation string.
    The resulting HTML should look like the following example. Recall the `${}` syntax for interpolating JavaScript variables into string templates.
-   `html <section class="patient" id="patient--1"> <h2 class="patient__name">Doug</h2> <div class="patient__properties"> <p>Age: 32</p> <p>Temperature: 101</p> <p>Diagnosed: true</p> </div> <div class="patient_diagnosis"> Infected: false </div> </section> `
+   ```html
+   <section class="patient" id="patient--1">
+     <h2 class="patient__name">Doug</h2>
+     <div class="patient__properties">
+       <p>Age: 32</p>
+       <p>Temperature: 101</p>
+       <p>Diagnosed: true</p>
+     </div>
+     <div class="patient_diagnosis">Infected: false</div>
+   </section>
+   ```
 1. The function must put all of the HTML representations into a single string. Recall that there are ways to turn an array's values into a single string.
 1. The function then must return that single string that has all of the patient HTML representation in it.
 1. In the `main.js` module, invoke the `PatientList` component function. Take the string of HTML representations that it returns and update the inner HTML of the article element you created in `index.html`. You need to remember how to get a reference to DOM element in JavaScript and then assign it some HTML.

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,13 +1,9 @@
 // Imports go first
 
-
-
-// Test 5 people at the testing facility
-let doug = testPerson()
-
+// Create and test 5 people at the testing facility
+let doug = testPerson();
 
 // Diagnose each person at the clinic
-doug = diagnose()
+doug = diagnose();
 
-
-// Invoke the component function that renders the HTML list of patients
+// Invoke the component function that returns the HTML string of patients and add it to the DOM

--- a/test/patient.diagnose.test.js
+++ b/test/patient.diagnose.test.js
@@ -1,49 +1,49 @@
-import testPerson from "../src/scripts/TestFacility.js"
-import clinic  from "../src/scripts/Clinic.js"
+import { testPerson } from "../src/scripts/TestFacility.js";
+import { diagnose } from "../src/scripts/Clinic.js";
 
-let person = null
+let person = null;
 
-describe('Testing a patient with infected conditions', () => {
+describe("Testing a patient with infected conditions", () => {
   beforeAll(() => {
-      person = testPerson("Doug", 65, 102)
-      person = clinic.diagnose(person, 4)
-  })
+    person = testPerson("Doug", 65, 102);
+    person = diagnose(person, 4);
+  });
 
-  test('Person is diagnosed', () => {
-      expect(person.diagnosed).toBe(true)
-  })
+  test("Person is diagnosed", () => {
+    expect(person.diagnosed).toBe(true);
+  });
 
-  test('Person is infected when temperature and symptomatic days are too high', () => {
-      expect(person.infected).toBe(true)
-  })
-})
+  test("Person is infected when temperature and symptomatic days are too high", () => {
+    expect(person.infected).toBe(true);
+  });
+});
 
-describe('Testing a patient with high temperature but not symptomatic long enough', () => {
+describe("Testing a patient with high temperature but not symptomatic long enough", () => {
   beforeAll(() => {
-      person = testPerson("Doug", 65, 102)
-      person = clinic.diagnose(person, 2)
-  })
+    person = testPerson("Doug", 65, 102);
+    person = diagnose(person, 2);
+  });
 
-  test('Person is diagnosed', () => {
-      expect(person.diagnosed).toBe(true)
-  })
+  test("Person is diagnosed", () => {
+    expect(person.diagnosed).toBe(true);
+  });
 
-  test('Person is not infected when days are too few', () => {
-      expect(person.infected).toBe(false)
-  })
-})
+  test("Person is not infected when days are too few", () => {
+    expect(person.infected).toBe(false);
+  });
+});
 
-describe('Testing a patient with low temperature and not symptomatic long enough', () => {
+describe("Testing a patient with low temperature and not symptomatic long enough", () => {
   beforeAll(() => {
-      person = testPerson("Doug", 65, 99)
-      person = clinic.diagnose(person, 2)
-  })
+    person = testPerson("Doug", 65, 99);
+    person = diagnose(person, 2);
+  });
 
-  test('Person is diagnosed', () => {
-      expect(person.diagnosed).toBe(true)
-  })
+  test("Person is diagnosed", () => {
+    expect(person.diagnosed).toBe(true);
+  });
 
-  test('Person is not infected when no conditions met', () => {
-      expect(person.infected).toBe(false)
-  })
-})
+  test("Person is not infected when no conditions met", () => {
+    expect(person.infected).toBe(false);
+  });
+});

--- a/test/patient.render.test.js
+++ b/test/patient.render.test.js
@@ -1,28 +1,26 @@
-import testPerson from "../src/scripts/TestFacility.js"
-import clinic  from "../src/scripts/Clinic.js"
-import patientList  from "../src/scripts/PatientList.js"
+import { testPerson } from "../src/scripts/TestFacility.js";
+import { diagnose } from "../src/scripts/Clinic.js";
+import { PatientList } from "../src/scripts/PatientList.js";
 
+test("Patients are rendered to DOM", async () => {
+  let doug = testPerson("Doug", 65, 102);
+  let mary = testPerson("Mary", 37, 100);
+  let candace = testPerson("Candace", 42, 103);
 
-test('Patients are rendered to DOM', async () => {
-  let doug = testPerson("Doug", 65, 102)
-  let mary = testPerson("Mary", 37, 100)
-  let candace = testPerson("Candace", 42, 103)
+  doug = diagnose(doug, 4);
+  mary = diagnose(mary, 2);
+  candace = diagnose(candace, 2);
 
-  doug = clinic.diagnose(doug, 4)
-  mary = clinic.diagnose(mary, 2)
-  candace = clinic.diagnose(candace, 2)
+  let constructedDOM = PatientList();
 
-
-  let constructedDOM = patientList()
-
-  constructedDOM = constructedDOM.replace(/\n/g, "")
-  constructedDOM = constructedDOM.replace(/\s{2,}/g, "")
+  constructedDOM = constructedDOM.replace(/\n/g, "");
+  constructedDOM = constructedDOM.replace(/\s{2,}/g, "");
 
   try {
-      expect(constructedDOM).toBe(`<section class="patient" id="patient--1"><h2 class="patient__name">Doug</h2><div class="patient__properties"><p>Age: 65</p><p>Temperature: 102</p><p>Diagnosed: true</p></div><div class="patient_diagnosis">Infected: true</div></section><section class="patient" id="patient--2"><h2 class="patient__name">Mary</h2><div class="patient__properties"><p>Age: 37</p><p>Temperature: 100</p><p>Diagnosed: true</p></div><div class="patient_diagnosis">Infected: false</div></section><section class="patient" id="patient--3"><h2 class="patient__name">Candace</h2><div class="patient__properties"><p>Age: 42</p><p>Temperature: 103</p><p>Diagnosed: true</p></div><div class="patient_diagnosis">Infected: false</div></section>`);
+    expect(constructedDOM).toBe(
+      `<section class="patient" id="patient--1"><h2 class="patient__name">Doug</h2><div class="patient__properties"><p>Age: 65</p><p>Temperature: 102</p><p>Diagnosed: true</p></div><div class="patient_diagnosis">Infected: true</div></section><section class="patient" id="patient--2"><h2 class="patient__name">Mary</h2><div class="patient__properties"><p>Age: 37</p><p>Temperature: 100</p><p>Diagnosed: true</p></div><div class="patient_diagnosis">Infected: false</div></section><section class="patient" id="patient--3"><h2 class="patient__name">Candace</h2><div class="patient__properties"><p>Age: 42</p><p>Temperature: 103</p><p>Diagnosed: true</p></div><div class="patient_diagnosis">Infected: false</div></section>`
+    );
+  } catch (error) {
+    throw error;
   }
-  catch (error) {
-      throw error
-  }
-
-})
+});

--- a/test/patient.testing.test.js
+++ b/test/patient.testing.test.js
@@ -1,18 +1,18 @@
-import testPerson from "../src/scripts/TestFacility.js"
+import { testPerson } from "../src/scripts/TestFacility.js";
 
-let person = null
+let person;
 
-describe('Person is tested and has an identifier', () => {
+describe("Person is tested and has an identifier", () => {
   beforeAll(() => {
-      person = testPerson("Doug", 65, 102)
-  })
+    person = testPerson("Doug", 65, 102);
+  });
 
-  test('Person has correct properties', () => {
-      expect(
-          person
-      )
-          .toMatchObject(
-              { firstName: "Doug", age: 65, temperature: 102, id: 1 }
-          )
-  })
-})
+  test("Person has correct properties", () => {
+    expect(person).toMatchObject({
+      firstName: "Doug",
+      age: 65,
+      temperature: 102,
+      id: 1,
+    });
+  });
+});


### PR DESCRIPTION
This PR switches the instructions to have students use named exports instead of default exports. 

This may only suit 43, who have only had exposure to named exports. If other classes are used to default exports, we can find another place for this. It also alleviates the possible complexity of exporting an object from `Clinic.js` whose property values are functions--another thing students (in 43) haven't seen yet.

Sorry about the linting diffs.... Whoever has to review this: I can revert those if you're militant about it.  